### PR TITLE
2 update docker for app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,7 @@ work_dir
 #demo.py
 develop/
 tmp.py
+
+#cache for docker
+docker/cache/gradio
+docker/cache/huggingface

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This is a sample Dockefile that builds a runtime container and runs the sample Gradio app.
 # Note, you must pass in the pretrained models when you run the container.
 
-FROM nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu22.04
+FROM nvidia/cuda:12.2.0-devel-ubuntu22.04
 
 WORKDIR /workspace
 
@@ -11,22 +11,17 @@ RUN apt-get update && \
         python3 \
         python-is-python3 \
         python3-pip \
+        python3.10-venv \
         libgl1 \
         libgl1-mesa-glx \ 
         libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
-
+    
 ADD requirements.txt .
 
-RUN pip install torch==2.0.0+cu117 torchvision==0.15.1+cu117 torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/cu117 && \
-    pip install -r requirements.txt
+RUN pip install -r requirements.txt
 
 ADD . .
 
-CMD ["/usr/bin/python", "/workspace/scripts/interface.py" ,"--port=12345", "--t5_path", "output/pretrained_models", "--model_path", "output/pretrained_models/PixArt-XL-2-1024-MS.pth"]
-
-# Build with
-# docker build . -t pixart
-
-# Run with 
-# docker run --gpus all -it -p 12345:12345 -v <path_to_models>:/workspace/output/pretrained_models pixart
+ENV DEMO_PORT=12345
+CMD [ "/usr/bin/python", "/workspace/scripts/app.py" ]

--- a/README.md
+++ b/README.md
@@ -243,7 +243,13 @@ As an alternative, a sample [Dockerfile](Dockerfile) is provided to make a runti
 
 ```bash
 docker build . -t pixart
-docker run --gpus all -it -p 12345:12345 -v <path_to_models>:/workspace/output/pretrained_models pixart
+docker run --gpus all -it -p 12345:12345 -v <path_to_huggingface_cache>:/root/.cache/huggingface pixart
+```
+
+Or use docker-compse
+```bash
+docker compose build
+docker compose up
 ```
 
 Let's have a look at a simple example using the `http://your-server-ip:12345`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.8"
+services:
+  pixart:
+    container_name: pixart
+    image: pixart:latest
+    build:
+      context: .
+    ports:
+      - 12345:12345
+    environment:
+      CLI_ARGS: ""
+    tmpfs:
+      - /tmp      
+    volumes:
+      - ./docker/cache/gradio:/workspace/gradio_cached_examples/30:rw
+      - ./docker/cache/huggingface:/root/.cache/huggingface:rw
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ['0']
+              capabilities: [gpu]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-torch==2.0.0+cu117
-torchvision==0.15.1+cu117
-torchaudio==2.0.1
+torch==2.1.1
+torchaudio==2.1.1
+torchvision==0.16.1
 mmcv==1.7.0
 git+https://github.com/huggingface/diffusers
 timm==0.6.12


### PR DESCRIPTION
pdated requirements to use torch that exists as 2.0.0+cu117 does not exist and therefore gradio app does not work

added docker-compose.yml to allow for docker compose build and docker compose up

switched docker to use the app.py version with advanced options

added example cache directory for models and output samples

upgrading to cuda 12.2 for docker

updated readme.md with updated docker instructions

added default docker cache directories to .gitignore